### PR TITLE
feat(ui): Update Button component

### DIFF
--- a/.changeset/nasty-apricots-raise.md
+++ b/.changeset/nasty-apricots-raise.md
@@ -1,0 +1,5 @@
+---
+"@wisihe/ui": patch
+---
+
+test

--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -1,14 +1,19 @@
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  type?: 'button' | 'submit' | 'reset';
   children: React.ReactNode;
 }
 
-export function Button({ children, ...other }: ButtonProps): JSX.Element {
+export function Button({
+  children,
+  type = 'button',
+  ...other
+}: ButtonProps): JSX.Element {
   return (
-    <button type="button" {...other}>
+    <button type={type} {...other}>
       {children}
     </button>
   );
 }
 
-Button.displayName = "Button";
+Button.displayName = 'Button';


### PR DESCRIPTION
- Added a new optional prop `type` to the `ButtonProps` interface
- Updated the `Button` component to use the `type` prop for the button element's type attribute
- Set the default value of `type` prop to `'button'`
- Updated the display name of the `Button` component to use single quotes instead of double quotes